### PR TITLE
Set deletion_protection to false in gke.tf

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -57,11 +57,7 @@ module "gke" {
   disable_legacy_metadata_endpoints = false
   cluster_autoscaling = var.cluster_autoscaling
   # Disable deletion protection 
-  update {
-    enabled = true
-    deletion_protection = false
-  }
-  #deletion_protection = false
+  deletion_protection = false
   # authenticator_security_group = "gke-security-group@company.com"
 
   node_pools = [


### PR DESCRIPTION
Set deletion_protection to false in gke.tf to allow Terraform delete the cluster.